### PR TITLE
Tests de Anonymous WorkPlans

### DIFF
--- a/src/main/java/acme/features/anonymous/workplan/AnonymousWorkplanRepository.java
+++ b/src/main/java/acme/features/anonymous/workplan/AnonymousWorkplanRepository.java
@@ -11,10 +11,10 @@ import acme.framework.repositories.AbstractRepository;
 @Repository
 public interface AnonymousWorkplanRepository extends AbstractRepository{
 	
-	@Query("SELECT w FROM Workplan w WHERE w.endDate > CURRENT_DATE ORDER BY w.startDate DESC")
+	@Query("SELECT w FROM Workplan w WHERE w.endDate > CURRENT_DATE AND w.publicPlan = TRUE ORDER BY w.startDate DESC")
 	Collection<Workplan> findPublicWorkplansNonFinished();
 	
-	@Query("SELECT w FROM Workplan w WHERE w.endDate > CURRENT_DATE AND w.id = ?1")
+	@Query("SELECT w FROM Workplan w WHERE w.endDate > CURRENT_DATE AND w.publicPlan = TRUE AND w.id = ?1")
 	Workplan findOnePublicWorkplansNonFinished(int id);
 	
 }

--- a/src/test/java/acme/testing/anonymous/workplan/AnonymousWorkPlanListTest.java
+++ b/src/test/java/acme/testing/anonymous/workplan/AnonymousWorkPlanListTest.java
@@ -1,0 +1,47 @@
+package acme.testing.anonymous.workplan;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
+
+import acme.testing.AcmePlannerTest;
+
+public class AnonymousWorkPlanListTest extends AcmePlannerTest {
+	
+	@ParameterizedTest
+	@CsvFileSource(resources="/anonymous/workplan/list.csv", encoding="utf-8", numLinesToSkip=1)
+	@Order(10)
+	public void listAndShowPositive(final int recordIndex, final String startDate, final String endDate, final String workLoad, final String publicPlan) {
+		super.clickOnMenu("Anonymous", "Workplans");
+		
+		super.checkColumnHasValue(recordIndex, 0, startDate);
+		super.checkColumnHasValue(recordIndex, 1, endDate);
+		super.checkColumnHasValue(recordIndex, 2, workLoad);
+		
+		
+		super.clickOnListingRecord(recordIndex);
+		super.checkInputBoxHasValue("startDate", startDate);
+		super.checkInputBoxHasValue("endDate", endDate);
+		super.checkInputBoxHasValue("workLoad", workLoad);
+		super.checkInputBoxHasValue("publicPlan", publicPlan);
+	
+	}
+	
+	@Test
+	@Order(20)
+	public void listManagerNegative() {
+		super.signIn("manager2", "manager2");
+		super.navigate("/anonymous/workplan/list","");
+		super.checkErrorsExist();
+	}
+	
+	@Test
+	@Order(30)
+	public void listAdministratorNegative() {
+		super.signIn("administrator", "administrator");
+		super.navigate("/anonymous/workplan/list","");
+		super.checkErrorsExist();
+	}
+
+}

--- a/src/test/resources/anonymous/workplan/list.csv
+++ b/src/test/resources/anonymous/workplan/list.csv
@@ -1,0 +1,3 @@
+recordIndex,startDate,endDate,workLoad,publicPlan
+2,2021/08/12 12:00,2021/08/12 15:00,2.00,true
+3,2021/07/30 10:00,2021/07/30 11:30,26.00,true


### PR DESCRIPTION
Pruebas de la funcionalidad Anonymous WorkPlans.

Mediante las pruebas me he dado cuenta que las querys de la clase AnonymousWorkplanRepository estaban mal hechas ya que seleccionaban los work plans tanto públicos como privados cuando sólo deberían de seleccionar los públicos. También he corregido esto.