### PR TITLE
Test/012 manager task

### DIFF
--- a/src/test/java/acme/testing/anonymous/workplan/AnonymousWorkPlanListTest.java
+++ b/src/test/java/acme/testing/anonymous/workplan/AnonymousWorkPlanListTest.java
@@ -39,7 +39,7 @@ public class AnonymousWorkPlanListTest extends AcmePlannerTest {
 	public void listManagerNegative() {
 		super.signIn("manager2", "manager2");
 		super.driver.get("http://localhost:8080/Acme-Planner/anonymous/workplan/list");
-		super.checkErrorsExist();
+		super.checkPanicExists();
 	}
 	
 	//Este test prueba la funcionalidad list workplan de forma negativa. Se intenta acceder al listado
@@ -50,7 +50,7 @@ public class AnonymousWorkPlanListTest extends AcmePlannerTest {
 	public void listAdministratorNegative() {
 		super.signIn("administrator", "administrator");
 		super.driver.get("http://localhost:8080/Acme-Planner/anonymous/workplan/list");
-		super.checkErrorsExist();
+		super.checkPanicExists();
 	}
 
 }

--- a/src/test/java/acme/testing/manager/task/ManagerMyTasksDeleteTest.java
+++ b/src/test/java/acme/testing/manager/task/ManagerMyTasksDeleteTest.java
@@ -54,8 +54,8 @@ public class ManagerMyTasksDeleteTest extends AcmePlannerTest {
 	@Order(20)
 	public void deleteNegativeAdministrator() {	
 		this.signIn("administrator", "administrator");
-		super.driver.get("http://localhost:8080/Acme-Planner/manager/task/delete?id=23");
-		super.checkErrorsExist();
+		super.driver.get("http://localhost:8080/Acme-Planner/manageracc/task/delete?id=23");
+		super.checkPanicExists();
 		this.signOut();
 	}
 	
@@ -65,8 +65,8 @@ public class ManagerMyTasksDeleteTest extends AcmePlannerTest {
 	@Test
 	@Order(30)
 	public void deleteNegativeAnonymous() {
-		super.driver.get("http://localhost:8080/Acme-Planner/manager/task/delete?id=23");
-		super.checkErrorsExist();
+		super.driver.get("http://localhost:8080/Acme-Planner/manageracc/task/delete?id=23");
+		super.checkPanicExists();
 	}
 	
 	//Se vuelve a probar la funcionalidad delete de tasks pero, ahora, accediendo a través de la URL.
@@ -76,9 +76,10 @@ public class ManagerMyTasksDeleteTest extends AcmePlannerTest {
 	@Test
 	@Order(40)
 	public void deleteTaskURL() {
-		super.signIn("manager2", "manager2");
-		super.driver.get("http://localhost:8080/Acme-Planner/manager/task/delete?id=23");
+		super.signIn("manager3", "manager3");
+		super.driver.get("http://localhost:8080/Acme-Planner/manageracc/task/delete?id=18");
 		super.clickOnSubmitButton("Delete");
+		super.checkNotPanicExists();
 		super.signOut();
 	}
 

--- a/src/test/java/acme/testing/manager/task/ManagerMyTasksListTest.java
+++ b/src/test/java/acme/testing/manager/task/ManagerMyTasksListTest.java
@@ -46,8 +46,8 @@ public class ManagerMyTasksListTest extends AcmePlannerTest {
 	@Test
 	@Order(20)
 	public void listNegativeAnonymous() {
-		super.driver.get("http://localhost:8080/Acme-Planner/manager/task/list");
-		super.checkErrorsExist();
+		super.driver.get("http://localhost:8080/Acme-Planner/manageracc/task/list");
+		super.checkPanicExists();
 	}
 	
 	//Aquí se vuelve a probar la funcionalidad list de tasks pero de forma negativa. El resultado esperado es
@@ -57,8 +57,8 @@ public class ManagerMyTasksListTest extends AcmePlannerTest {
 	@Order(30)
 	public void listNegativeAdministrator() {
 		this.signIn("administrator", "administrator");
-		super.driver.get("http://localhost:8080/Acme-Planner/manager/task/list");
-		super.checkErrorsExist();
+		super.driver.get("http://localhost:8080/Acme-Planner/manageracc/task/list");
+		super.checkPanicExists();
 	}
 
 }


### PR DESCRIPTION
Corrección de las URLs usadas en los test de manager/task/delete|list a manageracc/task/delete|list. Además se ha cambiado el método checkErrorExists por checkPanicExists en aquellos tests negativos en los que se intentaba acceder a una funcionalidad con un rol no autorizado.